### PR TITLE
Bugfix/dev-86 & dev-84 : destroy duplicate

### DIFF
--- a/Assets/Scenes/Scripts/Presentation/Controllers/General/GeneralController.cs
+++ b/Assets/Scenes/Scripts/Presentation/Controllers/General/GeneralController.cs
@@ -104,6 +104,8 @@ namespace LegoBattaleRoyal.Presentation.Controllers.General
             popup.SetText($"There are {_walletController.GetCurrentMoney()} energy in your wallet. Restart for {currentLevel.Price}");
             popup.Show();
 
+            popup.transform.SetParent(_generalPopup.transform.parent);
+            popup.RectTransform.anchoredPosition = Vector2.one;
             popup.transform.localScale = Vector3.one;
         }
 

--- a/Assets/Scenes/Scripts/Presentation/Controllers/Wallet/WalletController.cs
+++ b/Assets/Scenes/Scripts/Presentation/Controllers/Wallet/WalletController.cs
@@ -1,6 +1,5 @@
 using LegoBattaleRoyal.App.AppService;
 using LegoBattaleRoyal.App.DTO.Wallet;
-using LegoBattaleRoyal.ApplicationLayer.SaveSystem;
 using LegoBattaleRoyal.Core.Wallet;
 using LegoBattaleRoyal.ScriptableObjects;
 using System;
@@ -12,7 +11,7 @@ namespace LegoBattaleRoyal.Presentation.Controllers.Wallet
         public event Action<int> Changed;
 
         private WalletModel _walletModel;
-        private readonly ISaveService _saveService;
+        private readonly SaveService _saveService;
         private readonly GameSettingsSO _gameSettingsSO;
 
         public WalletController(SaveService saveService, GameSettingsSO gameSettingsSO)


### PR DESCRIPTION
------- ISaveService - исправлено обратно на SaveService, тк иначе не переходит на уровни (рестарт либо след уровень). 

-------   этого   Бага нет в новой версии:
DEV-86: Дублированная кнопка show ads при ресете 
https://tracker.yandex.ru/DEV-86

-------   этого   Бага нет в новой версии:
DEV-84: Поехала верстка окна победы (кнопки) на 11 уровне
https://tracker.yandex.ru/DEV-84

-------- Добавлена снова часть с SetParent() так как необходимо задать parent для того, чтобы создание происходило в canvas, а не как обычный обьект в иерархии. Для того, чтобы scale был верный - добавленная часть с localScale также в коде.
https://tracker.yandex.ru/DEV-7
DEV-7: EndGame UI